### PR TITLE
Platform admin ria pickcook

### DIFF
--- a/src/dto/pickcook/reservation/reservation-update.dto.ts
+++ b/src/dto/pickcook/reservation/reservation-update.dto.ts
@@ -2,6 +2,6 @@ import { BaseDto } from '@/core';
 import { RESERVATION_HOURS } from '@/services/shared';
 
 export class ReservationUpdateDto extends BaseDto<ReservationUpdateDto> {
-  reservationDate: Date;
+  reservationDate: Date | string;
   reservationTime: RESERVATION_HOURS;
 }

--- a/src/modules/pickcook/consult-response/components/ConsultResponseDetail.vue
+++ b/src/modules/pickcook/consult-response/components/ConsultResponseDetail.vue
@@ -943,7 +943,7 @@ export default class ConsultResponseDetail extends BaseComponent {
           this.consultResponseDto.reservation &&
           this.consultResponseDto.reservation.isCancelYn !== 'Y'
         ) {
-          this.reservationUpdateDto.reservationDate = this.consultResponseDto.reservation.reservationDate;
+          this.reservationUpdateDto.reservationDate = this.consultResponseDto.reservation.formatReservationDate;
           this.reservationUpdateDto.reservationTime = this.consultResponseDto.reservation.reservationTime;
           this.getReservationTimes(
             this.consultResponseDto.reservation.reservationDate


### PR DESCRIPTION
픽쿡 상세 예약 날짜 표시 버그 발견 추후 확인후 반영 필요
(사용자가 예약했을때랑, 관리자가 수정했을때 저장되는 날짜 포맷이 다른듯)